### PR TITLE
Updates provider version

### DIFF
--- a/.github/workflows/code-quality-terraform.yml
+++ b/.github/workflows/code-quality-terraform.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-  TERRAFORM_VERSION: 0.12.20
+  TERRAFORM_VERSION: 0.13.2
   TERRAFORM_ACTIONS_COMMENT: true
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ## Requirements
 
-This module requires Terraform version `0.12.0` or newer.
+This module requires Terraform version `0.13.0` or newer.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Add the module to your Terraform resources like so:
 ```hcl
 module "org-verification" {
   source              = "operatehappy/route53-github-verification/aws"
-  version             = "1.0.2"
+  version             = "1.1.0"
   github_organization = "operatehappy"
   ownership_record    = "38834dez61"
   zone_id             = "Z3P5QSUBK4POTI"

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.0"
+  required_version = ">= 0.13.0"
 
   required_providers {
     aws = "> 2.10.0"

--- a/terraform.tf
+++ b/terraform.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.13.0"
 
   required_providers {
-    aws = "> 2.10.0"
+    aws = ">= 3.4.0"
   }
 }


### PR DESCRIPTION
This PR updates the underlying version of Terraform (`0.12.20` to `0.13.2`) and the AWS Provider (to `3.4.0`)

I intend to release this as `1.1.0`